### PR TITLE
Added a 'default' JSON Read method

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,24 @@ ReadJson(__dirname + "/test.json", function (err, data) {
 
 // Read the same file synchronously
 console.log(ReadJson(__dirname + "/test.json"));
+
+// Read another JSON file asynchronously, with a default value and a custom w_json config
+ReadJson.defaultRead(
+    "./test2.json",
+    {myDefaultKey: "myDefaultValue"},
+    { new_line: true, space: 4},
+    function (err, data) {
+        console.log(err || data);
+    }
+);
+
+// Read the other JSON file synchronously, with a default value
+console.log(
+    ReadJson.defaultRead(
+        "./test2.json",
+        {myDefaultKey: "myDefaultValue"}
+    )
+);
 ```
 
 
@@ -122,6 +140,18 @@ There are few ways to get help:
 - **String** `path`: The JSON file path.
 - **Function** `callback`: An optional callback. If not passed, the function will run in sync mode.
 
+### `rJson_default(path, def_value, w_json_options, callback)`
+
+#### Params
+
+- **String** `path`: The JSON file path.
+- **Object** `def_value`: The Default Value
+- **Object|Number|Boolean|undefined** `w_json_options`: Optional: w-json config object containing the fields below.
+    If boolean, it will be handled as `new_line`, if number it will be handled as `space`.
+     - `space` (Number): An optional space value for beautifying the json output (default: `2`).
+     - `new_line` (Boolean): If `true`, a new line character will be added at the end of the stringified content.
+    You can refer to [node-w-json](https://github.com/IonicaBizau/node-w-json) docs for information on this
+- **Function** `callback`: An optional callback. If not passed, the function will run in sync mode.
 
 
 

--- a/example/index.js
+++ b/example/index.js
@@ -8,3 +8,21 @@ ReadJson(__dirname + "/test.json", function (err, data) {
 
 // Read the same file synchronously
 console.log(ReadJson(__dirname + "/test.json"));
+
+// Read another JSON file asynchronously, with a default value and a custom w_json config
+ReadJson.defaultRead(
+    "./test2.json",
+    {myDefaultKey: "myDefaultValue"},
+    { new_line: true, space: 4},
+    function (err, data) {
+        console.log(err || data);
+    }
+);
+
+// Read the other JSON file synchronously, with a default value
+console.log(
+    ReadJson.defaultRead(
+        "./test2.json",
+        {myDefaultKey: "myDefaultValue"}
+    )
+);

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,6 @@
 // Dependencies
 var Fs = require("fs");
+var WriteJson = require("w-json");
 
 /**
  * rJson
@@ -26,4 +27,58 @@ function rJson(path, callback) {
     return JSON.parse(Fs.readFileSync(path));
 }
 
+/**
+ * rJson_default
+ * 
+ * If there is some error in reading the JSON file, this would overwrite the file with the default
+ *      value and return the same.
+ * This uses [node-w-json](https://github.com/IonicaBizau/node-w-json) for writing the default JSON
+ *      value and so you can pass configs to node-w-json to beautify the file written
+ *
+ * @name rJson_default
+ * @function
+ * @param {String} path The JSON file path.
+ * @param {Object} def_value The Default Value
+ * @param {Object|Number|Boolean} w_json_options Optional: w-json config object containing the fields below.
+ * If boolean, it will be handled as `new_line`, if number it will be handled as `space`.
+ *
+ *  - `space` (Number): An optional space value for beautifying the json output (default: `2`).
+ *  - `new_line` (Boolean): If `true`, a new line character will be added at the end of the stringified content.
+ *
+ * @param {Function} callback An optional callback. If not passed, the function will run in sync mode.
+ */
+function rJson_default(path, def_value, w_json_options, callback) {
+    if(def_value == undefined){
+        def_value = {};
+    }
+    if (typeof w_json_options === "function") {
+        callback = w_json_options;
+        w_json_options = {};
+    }
+
+    if (typeof callback === "function") {
+        return Fs.readFile(path, "utf-8", function (err, data) {
+            try {
+                data = JSON.parse(data);
+                callback(null, data);
+            } catch (e) {
+                err = null;
+                data = def_value;
+                try{ WriteJson(path, def_value, w_json_options); }
+                catch(e2){ err = err || e2; }
+                callback(err, data);
+            }
+        });
+    }
+
+    try{
+        return JSON.parse(Fs.readFileSync(path));
+    }
+    catch(err){
+        WriteJson(path, def_value, w_json_options);
+        return def_value;
+    }
+}
+
 module.exports = rJson;
+module.exports.defaultRead = rJson_default;

--- a/package.json
+++ b/package.json
@@ -41,5 +41,8 @@
     "bloggify.js",
     "bloggify.json",
     "bloggify/"
-  ]
+  ],
+  "dependencies": {
+    "w-json": "1.3.10"
+  }
 }


### PR DESCRIPTION
With this method, if there is an issue in the file...
 - The file is missing
 - The content is not a proper JSON
..., we can write a default JSON value to the file and get it returned instead of error

This is my first open-source contribution to a repo that is not mine, and this as a part of [Hacktoberfest](https://hacktoberfest.digitalocean.com/). Waiting for a **hacktoberfest-accepted** label! Please let me know if the PR needs some corrections